### PR TITLE
Fixed linking flag in Makefile for build with gcc 5.4.0

### DIFF
--- a/source/provers.src/Makefile
+++ b/source/provers.src/Makefile
@@ -63,25 +63,25 @@ prover:
 	$(MAKE) prover9
 
 prover9: prover9.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o prover9 prover9.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o prover9 prover9.o $(OBJECTS) ../ladr/libladr.a -lm
 
 fof-prover9: fof-prover9.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o fof-prover9 fof-prover9.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o fof-prover9 fof-prover9.o $(OBJECTS) ../ladr/libladr.a -lm
 
 ladr_to_tptp: ladr_to_tptp.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o ladr_to_tptp ladr_to_tptp.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o ladr_to_tptp ladr_to_tptp.o $(OBJECTS) ../ladr/libladr.a -lm
 
 tptp_to_ladr: tptp_to_ladr.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o tptp_to_ladr tptp_to_ladr.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o tptp_to_ladr tptp_to_ladr.o $(OBJECTS) ../ladr/libladr.a -lm
 
 autosketches4: autosketches4.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o autosketches4 autosketches4.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o autosketches4 autosketches4.o $(OBJECTS) ../ladr/libladr.a -lm
 
 newauto: newauto.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o newauto newauto.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o newauto newauto.o $(OBJECTS) ../ladr/libladr.a -lm
 
 newsax: newsax.o $(OBJECTS)
-	$(CC) $(CFLAGS) -lm -o newsax newsax.o $(OBJECTS) ../ladr/libladr.a
+	$(CC) $(CFLAGS)  -o newsax newsax.o $(OBJECTS) ../ladr/libladr.a -lm
 
 cgrep: cgrep.o $(OBJECTS)
 	$(CC) $(CFLAGS) -o cgrep cgrep.o $(OBJECTS) ../ladr/libladr.a


### PR DESCRIPTION
I've been searching a while for a solution to my build problem - moving the -lm flags from in between to the end of the line did the job.

Source: http://www.faqs.org/faqs/C-faq/faq/       Answer to Question 14.3